### PR TITLE
fixed rescaling and removed 3d samples from DataLoader

### DIFF
--- a/Dataset.py
+++ b/Dataset.py
@@ -14,7 +14,6 @@ import torchvision.transforms.functional as fn
 from PIL import Image
 from torch.utils.data import Dataset
 
-# from utilities import __fetchOneImg
 random.seed(0)
 np.random.seed(0)
 
@@ -55,6 +54,7 @@ class ImageDataset(Dataset):
         url = f"https://nc.mlcloud.uni-tuebingen.de/index.php/s/TgSK4n8ctPbWP4K/download?path=%2F{dict['label']}&files={dict['img']}"
         return url, imgName
 
+    # fetches one image from the server in saves it to imgFolder
     def __fetchOneImg(self, imgIndex, imgFolder):
         url, img = self.__createUrl(imgIndex)
         response = requests.get(url)
@@ -85,10 +85,9 @@ class DataLoader(Dataset):
         self.index = index
         (picture, label, source) = self.__transform(index)
         image = self.pilToTensor(picture)
-        sample3dim = {'image': image, 'label': label}
         image = image.unsqueeze(0)
         sample = {'image': image, 'label': label}
-        return sample, sample3dim, source
+        return sample, source
 
     # Constants for the size of the images
 
@@ -97,10 +96,11 @@ class DataLoader(Dataset):
     # return: tuple(PIL Image, label)
     def __transform(self, index):
         assert index <= len(imageDataset)
+        FINAL_SIZE = 224
         image, label, source = imageDataset[index]
         rescaledImage = fn.resize(img=image, size=[self.SIZE, self.SIZE], interpolation=T.InterpolationMode.BICUBIC)
-        __transformedImage = fn.center_crop(img=rescaledImage, output_size=[self.SIZE, self.SIZE])
-        return __transformedImage, label, source
+        transformedImage = fn.center_crop(img=rescaledImage, output_size=[FINAL_SIZE, FINAL_SIZE])
+        return transformedImage, label, source
 
 
 dataloader = DataLoader(len(imageDataset))

--- a/utilities.py
+++ b/utilities.py
@@ -2,9 +2,10 @@ import csv
 import json
 import os
 import random
-
+import matplotlib.pyplot as plt
 import numpy as np
 import torch
+import torchvision
 import torch.nn.functional as F
 import torchvision.transforms as T
 import torchvision.transforms.functional as fn
@@ -22,12 +23,11 @@ import time
 random.seed(0)
 np.random.seed(0)
 
-# from Dataset import imageDataset, dataloader
-
 
 # Constants for the size of the images
 
 SIZE = round(224 / 0.875)
+FINAL_SIZE = 224
 
 
 def createAnnotation(folderPath):
@@ -92,7 +92,7 @@ Return: list[dict[image:tensor,label:str, prediction:tensor]]
 def feedModel(img, model, path):
     image = Image.open(path + img)
     image = fn.resize(img=image, size=[SIZE, SIZE], interpolation=T.InterpolationMode.BICUBIC)
-    image = fn.center_crop(img=image, output_size=[SIZE, SIZE])
+    image = fn.center_crop(img=image, output_size=[FINAL_SIZE, FINAL_SIZE])
     image = pilToTensor(image)
     image = image.unsqueeze(0)
 
@@ -182,7 +182,7 @@ def createRandomBatch(batchsize, uId):
             continue
 
         indexList.append(index)
-        sample, sample3dim, source = dataloader[index]
+        sample, source = dataloader[index]
 
         sourceList.append(source)
         imgFile = source.split('/')[-1]


### PR DESCRIPTION
##Resolves 
I've changed the size from resize_center_crop to 224 instead of 224/0.875
## Changes
- added comments
- changed output size of images to 224 (after center crop)
- removed samples3dim from DataLoader.__getitem__


